### PR TITLE
Create new checker for every jscs target run

### DIFF
--- a/tasks/jscs.js
+++ b/tasks/jscs.js
@@ -3,13 +3,14 @@ module.exports = function( grunt ) {
 
     var fs = require( "fs" );
     var path = require( "path" );
-    var jscs = new (require( "jscs/lib/checker" ))();
+    var Checker = require( "jscs/lib/checker" );
     var defaults = {
         config: ".jscs.json"
     };
 
     grunt.registerMultiTask( "jscs", "JavaScript Code Style checker", function() {
         var errorCount, i;
+        var jscs = new Checker();
         var options = this.options( defaults );
         var cfgPath = options.config;
         var files = this.filesSrc;


### PR DESCRIPTION
Say, for example, you have this in <code>Gruntfile</code>

``` js
jscs: {
    main: "main.js",
    secondary: "secondary.js"
}
```

You don't have errors in <code>main.js</code>, but you do have one in <code>secondary.js</code>.
Then, you run <code>grunt jscs</code> command without specifying the target, as a result, both targets will be run.
In stdout you get three absolutely identical errors found in <code>secondary.js</code>, instead of one.
<br/>

This would happen because

``` js
jscs.registerDefaultRules();
jscs.configure( require( cfgPath ) );
```

lines will be executed twice, whereas <code>Checker</code> constructor (which is initialized from out of context of <code>jscs</code> task) saves the rules in the returned object, so they will be augment every time.

This commit resolves the problem.
