### PR TITLE
Take "excludeFiles" options into the account

### DIFF
--- a/tasks/jscs.js
+++ b/tasks/jscs.js
@@ -31,6 +31,11 @@ module.exports = function( grunt ) {
 
         errorCount = i = 0;
         files.map( jscs.checkFile, jscs ).forEach(function( promise ) {
+            if ( !promise ) {
+                i++;
+                return;
+            }
+
             promise.then(function( errors ) {
                 i++;
 


### PR DESCRIPTION
<code>jscs</code> package has <code>excludeFiles</code> option, if file is included in that array, and that file passed to the <code>checkFile</code> method, it will ignore this path and will return <code>null</code> instead of a promise.

This commit take this behaviour into the account.
