### PR TITLE
Bump jscs to 1.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "url": "https://github.com/gustavohenke/grunt-jscs-checker/issues"
     },
     "dependencies": {
-        "jscs": "1.0.13",
+        "jscs": "1.0.14",
         "xmlbuilder": "0.4.3"
     },
     "devDependencies": {


### PR DESCRIPTION
Maybe a better idea to change go `~1.0.14` to allow minor patch versions, but I didn't want to alter your current fixed version approach.
