### PR TITLE
Update jscs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "url": "https://github.com/gustavohenke/grunt-jscs-checker/issues"
     },
     "dependencies": {
-        "jscs": "1.2.0",
+        "jscs": "~1.2.0",
         "vow": "0.4.0",
         "hooker": "0.2.3",
 


### PR DESCRIPTION
Relaxing the jscs dependency since jscs already went from 1.2.0 to 1.2.2 yesterday (a couple of minor bugfixes).
