### PR TITLE
Bump JSCS to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "hooker": "~0.2.3",
-        "jscs": "~1.4.5",
+        "jscs": "~1.5.1",
         "lodash.assign": "~2.4.1",
         "vow": "~0.4.1"
     },


### PR DESCRIPTION
Apparently, I accidentally unpublished 1.5.0. :-\
