### PR TITLE
This message is too cryptic

### DIFF
--- a/tasks/lib/jscs.js
+++ b/tasks/lib/jscs.js
@@ -111,7 +111,7 @@ exports.init = function( grunt ) {
                 }
 
             } else {
-                grunt.fatal( "Nor config file nor inline options weren't found" );
+                grunt.fatal( "JSCS configuration not found" );
             }
         }
 


### PR DESCRIPTION
Make it simple, consistent with other error messages and points the developer to the docs for further information.
