### PR TITLE
Correctly handle folders.

### DIFF
--- a/tasks/jscs.js
+++ b/tasks/jscs.js
@@ -28,9 +28,10 @@ module.exports = function( grunt ) {
                 return promise.isFulfilled();
 
             // Make array of errors
-            }).map(function( promise ) {
-                return promise.valueOf()[ 0 ];
-            });
+            }).reduce(function( memo, promise ) {
+                memo.push.apply(memo, promise.valueOf());
+                return memo
+            }, []);
 
             jscs.setErrors( results ).report().notify();
 


### PR DESCRIPTION
With a Gruntfile like this:

``` js
    jscs: {
      files: [ '.' ],
      options: {
        config: true,
      }
    }
```

Only style issues for the first file in the folder get reported. This fixes this issue so that style issues for all files inside the `.` folder get reported.
