### PR TITLE
convert reporter option toString

### DIFF
--- a/tasks/lib/jscs.js
+++ b/tasks/lib/jscs.js
@@ -167,7 +167,7 @@ exports.init = function( grunt ) {
             return this;
         }
 
-        var reporter = jscsConfig.getReporter( name );
+        var reporter = jscsConfig.getReporter( name.toString() );
 
         if ( reporter.writer ) {
             this._reporter = reporter.writer;


### PR DESCRIPTION
similar to grunt-contrib-jshint

This makes the interface even cleaner for reporters that expose .toString

see grunt-contrib-jshint: https://github.com/gruntjs/grunt-contrib-jshint/blob/040ab8009ec1108744dfd14b0f3abd882d0854c6/tasks/lib/jshint.js#L49