### PR TITLE
Remove grunt-bump

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,25 +2,6 @@ module.exports = function( grunt ) {
     "use strict";
 
     grunt.initConfig( {
-        bump: {
-            options: {
-                files: [ "package.json" ],
-
-                // Commit
-                commit: true,
-                commitMessage: "Release v%VERSION%",
-                commitFiles: [ "package.json" ],
-
-                // Tag
-                createTag: true,
-                tagName: "%VERSION%",
-                tagMessage: "Version %VERSION%",
-
-                // Push
-                push: true,
-                pushTo: "origin"
-            }
-        },
         jshint: {
             options: {
                 jshintrc: ".jshintrc"

--- a/MAINTAN.md
+++ b/MAINTAN.md
@@ -1,0 +1,13 @@
+# Maintainer Guide
+
+## Publishing a new version
+
+1. Determine which part of the version you are about to increase.
+   We follow the [Versioning & Semver](http://jscs.info/overview.html#versioning-semver) section from the JSCS project.
+2. Run a bump script via npm. This will commit and tag the changed files:
+    - `npm run bump` - will increase the patch version;
+    - `npm run bump-minor` - will increase the minor version.
+3. Push changes and tags: `git push --follow-tags`
+4. Wait until the Travis-CI build finishes. It will publish a new version into npm.
+   __DO NOT USE__ `npm publish`! If something goes wrong, Travis will tell us.
+5. Done!

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
         "node": ">= 0.10.0"
     },
     "scripts": {
-        "test": "grunt test"
+        "test": "grunt test",
+        "bump": "npm version patch -m \"Release v%s\"",
+        "bump-minor": "npm version minor -m \"Release v%s\""
     },
     "files": [
         "tasks",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "vow": "~0.4.1"
     },
     "devDependencies": {
-        "grunt-bump": "~0.0.13",
         "grunt-cli": "~0.1.13",
         "grunt-contrib-jshint": "~0.10.0",
         "grunt-contrib-nodeunit": "~0.4.0",


### PR DESCRIPTION
@markelog, feedback please?

- We may simplify the process by using directly `npm version patch` or `npm version minor`. I created the npm scripts because that allows to keep the same commit message style.
- The tags will now have a `v` prefix, unless we set [`tag-version-prefix`](https://docs.npmjs.com/misc/config#tag-version-prefix) config, but that's another factor to increase complexity of the bump process.

Closes #87 