### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "grunt-cli": "~0.1.13",
-    "grunt-contrib-jshint": "~0.11.2",
+    "grunt-contrib-jshint": "~0.11.3",
     "grunt-contrib-nodeunit": "~0.4.0",
     "load-grunt-tasks": "^3.3.0",
     "time-grunt": "~1.2.1"


### PR DESCRIPTION
Joshing grunt was using the very lates joshing version at 0.11.2 so upgrading to 0.11.3 down grades the joshing version to 2.8 since 2.9 had regressions.