### PR TITLE
Update jscs to 2.10.1, Also update grunt-contrib-jshint to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   },
   "dependencies": {
     "hooker": "~0.2.3",
-    "jscs": "~2.9.0",
+    "jscs": "~2.10.1",
     "lodash": "4.1.0",
     "vow": "~0.4.1"
   },
   "devDependencies": {
     "grunt": "0.4.5",
     "grunt-cli": "~0.1.13",
-    "grunt-contrib-jshint": "~0.12.0",
+    "grunt-contrib-jshint": "~1.0.0",
     "grunt-contrib-nodeunit": "~0.4.0",
     "load-grunt-tasks": "^3.3.0",
     "time-grunt": "~1.3.0"


### PR DESCRIPTION
The update to grunt-contrib-jshint only fixes a problem with where sometimes it wont tell you the file where the error is coming from this update fixes it.

Update jscs to 2.10.1