### PR TITLE
Added reporterOutputOnly flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Default value: `null`
 
 Specify a filepath to output the results of a reporter. If `reporterOutput` is specified then all output will be written to the given filepath instead of printed to stdout.
 
+#### reporterOutputOnly
+Type: `Boolean`
+Default value: `true`
+
+Determines if the output of a reporter should be written to only the `reporterOutput` filepath. If this is `false` the output will be written to both stdout and the given filepath.
+
 ### Usage examples
 ```js
 jscs: {

--- a/tasks/lib/jscs.js
+++ b/tasks/lib/jscs.js
@@ -9,7 +9,7 @@ var Checker = require( "jscs" ),
 exports.init = function( grunt ) {
 
     // Task specific options
-    var taskOptions = [ "config", "force", "reporter", "reporterOutput" ];
+    var taskOptions = [ "config", "force", "reporter", "reporterOutput", "reporterOutputOnly" ];
 
     /**
      * Default reporter
@@ -216,14 +216,21 @@ exports.init = function( grunt ) {
     JSCS.prototype.report = function() {
         var options = this.options,
             shouldHook = options.reporterOutput,
+            suppressStdOut = options.reporterOutputOnly,
             content = "";
+
+        if ( suppressStdOut === undefined ) {
+            suppressStdOut = true;
+        }
 
         if ( shouldHook ) {
             hooker.hook( process.stdout, "write", {
                 pre: function( out ) {
                     content += out;
 
-                    return hooker.preempt();
+                    if ( suppressStdOut ) {
+                        return hooker.preempt();
+                    }
                 }
             });
         }

--- a/test/methods.js
+++ b/test/methods.js
@@ -96,12 +96,14 @@ module.exports = {
             config: "config",
             force: true,
             reporterOutput: "reporterOutput",
+            reporterOutputOnly: "reporterOutputOnly",
             reporter: ""
         }).getConfig();
 
         test.ok( !config.config, "config option should be removed" );
         test.ok( !config.force, "force option should be removed" );
-        test.ok( !config.reporterOuput, "reporterOuput option should be removed" );
+        test.ok( !config.reporterOuput, "reporterOutput option should be removed" );
+        test.ok( !config.reporterOuputOnly, "reporterOutputOnly option should be removed" );
         test.ok( !config.reporter, "reporter option should be removed" );
         test.ok( !!config.requireCurlyBraces, "requireCurlyBraces should stay" );
 
@@ -244,6 +246,39 @@ module.exports = {
 
             grunt.file.delete( "#23" );
 
+            test.done();
+        });
+    },
+
+    "Reporter should be outputable to stdout and the file (#24)": function( test ) {
+        var jscs = new JSCS({
+            reporterOutput: "#24",
+            reporterOutputOnly: false,
+            "requireCurlyBraces": [ "while" ]
+        });
+
+        jscs.execute( "test/fixtures/fixture.js" ).then(function( errorsCollection ) {
+            hooker.hook( grunt.log, {
+                pre: function( message ) {
+                    test.ok( message, "all output should be directed to stdout" );
+                    console.log( "expected stdout output" );
+
+                    return hooker.preempt();
+                },
+
+                once: true
+            });
+
+            jscs.setErrors( errorsCollection ).report();
+            test.ok(
+                grunt.file.read( "#24" ).length,
+                "all output should also be directed to the file"
+            );
+
+            grunt.file.delete( "#24" );
+
+            test.expect( 2 );
+            hooker.unhook( grunt.log );
             test.done();
         });
     },


### PR DESCRIPTION
This flag allows for a reporter to send output both to stdout and a
specified filepath.