### PR TITLE
Update grunt to 1.0.1 and update grunt-contrib-nodeunit to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,9 @@
     "vow": "~0.4.1"
   },
   "devDependencies": {
-    "grunt": "0.4.5",
-    "grunt-cli": "~0.1.13",
+    "grunt": "1.0.1",
     "grunt-contrib-jshint": "~1.0.0",
-    "grunt-contrib-nodeunit": "~0.4.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
     "load-grunt-tasks": "^3.4.0",
     "time-grunt": "~1.3.0"
   },


### PR DESCRIPTION
grunt-cli is now included in grunt so doint need to add it separately now.